### PR TITLE
Adding compatibility with Mail Framework Mod

### DIFF
--- a/FeTK/Framework/Services/MailService/MailManager.cs
+++ b/FeTK/Framework/Services/MailService/MailManager.cs
@@ -266,6 +266,10 @@ namespace FelixDev.StardewMods.FeTK.Framework.Services
                 // item).
                 if (!this.registeredMailsMetaData.TryGetValue(mailId, out MailMetaData mailMetaData))
                 {
+                    if (typeof(LetterViewerMenu) != letterMenu.GetType())
+                    {
+                        return;
+                    }
                     string mailContent = GetMailContentForGameMail(mailId);
 
                     // Create and show the menu for this mail.


### PR DESCRIPTION
Adding a check that, when the letter was not added with FeTK, it also check is it's a LetterViewerMenu.
If it's not, it's probably a sub classe added by another mod, so it does nothing in that case. 
Otherwise, it does was it's supposed to do with the vanilla mail.